### PR TITLE
Ignore raw Figma token file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 build
+tokens/figma-raw.json

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install
 FIGMA_TOKEN=your-token FIGMA_FILE_KEY=your-file npm run pull-figma
 ```
 
-The raw Figma response will be written to `tokens/figma-raw.json`. You can use Tokens Studio's "sync with repository" features to export tokens in DTCG format.
+The raw Figma response will be written to `tokens/figma-raw.json` (this file is ignored by Git). You can use Tokens Studio's "sync with repository" features to export tokens in DTCG format.
 
 3. Build tokens for all platforms:
 

--- a/config.js
+++ b/config.js
@@ -4,7 +4,7 @@ import { register } from '@tokens-studio/sd-transforms';
 register(StyleDictionary);
 
 export default {
-  source: ['tokens/**/*.json'],
+  source: ['tokens/**/*.json', '!tokens/figma-raw.json'],
   preprocessors: ['tokens-studio'],
   platforms: {
     web: {


### PR DESCRIPTION
## Summary
- exclude `tokens/figma-raw.json` from Style Dictionary build
- ignore `tokens/figma-raw.json` in git
- note in the README that the file is ignored

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875a35ce8e4832696505e5a9e170740